### PR TITLE
Simplify "set -- ..." and fix running on Bash

### DIFF
--- a/bin/dwm.tmux
+++ b/bin/dwm.tmux
@@ -90,7 +90,7 @@ fi
 
 command=$1;shift
 args=$*
-set -- $(echo $(tmux display -p "#{window_panes}\n#{killlast}\n#{mfact}"))
+set -- $(tmux display -p "#{window_panes} #{killlast} #{mfact}")
 window_panes=$1
 killlast=$2
 mfact=$3


### PR DESCRIPTION
Bash breaks with POSIX in that it does not interpret "\n" in a simple "echo". For Bash, it would have to be "echo -e ...".

But "echo" is not needed here anyway. Just separate the variables by spaces and let the shell's word splitting routines do the work (which is the same as before, actually, just without an extra step).