### PR TITLE
add monocle mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ echo 'source-file /usr/local/lib/dwm.tmux' >> $HOME/.tmux.conf
 - `newpanecurdir` `Meta-w` Create a new pane starting in the same directory and place it in the Main pane
 - `killpane` `Meta-c` Close the current pane. If the pane is in the Main pane, close the pane and promote the first pane in the stack to the Main pane
 - `movepane[0-9]` `Meta-Shift-[0-9]` Move the current pane to the specified window
-- `nextpane` `Meta-j` Select the next pane (clockwise)
-- `prevpane` `Meta-k` Select the previous pane (counterclockwise)
+- `nextpane` `Meta-j` Select the next pane (clockwise); swaps fullscreen pane in monocle mode
+- `prevpane` `Meta-k` Select the previous pane (counterclockwise); swaps fullscreen pane in monocle mode
 - `rotateccw` `Meta-<` Rotate panes counterclockwise
 - `rotatecw` `Meta->` Rotate panes clockwise
-- `layouttile` `Meta-t` Refresh layout (return to Main and Stack setup)
+- `tile` `Meta-t` Return to tiled layout, exiting monocle if active
+- `monocle` `Meta-Space` Toggle monocle mode (fullscreen current pane)
 - `zoom` `Meta-Enter` Place select pane in the Main pane
-- `float` `Meta-Space` Switch pane to floating fullscreen
 - `decmfact` `Meta-h` Decrease the main pane space factor
 - `incmfact` `Meta-l` Increase the main pane space factor
 - `window[0-9]` `Meta-[0-9]` Select the target window by ID
@@ -56,6 +56,7 @@ Also defined are environment variables to tweak behavior:
 
 - `mfact` Main pane space factor, the size of the main pane as a percentage of total window size
 - `killlast` If value is greater than `0`, kill pane even if its the last pane in a window
+- `monocle` Tracks active layout mode; 0 for tile, 1 for monocle. Set automatically but can be read to inspect current state.
 
 ### Customizations
 Keybindings and default values can be set in a configuration file:
@@ -63,7 +64,7 @@ Keybindings and default values can be set in a configuration file:
 ```
 setenv -g killlast 1 # kill pane even if it's the last
 bind -n M-q killpane
-bind -n M-t newpanecurdir
+bind -n M-w newpanecurdir
 ```
 
 Customizations should be added after the `source-file` command which loads `dwm.tmux`.

--- a/bin/dwm.tmux
+++ b/bin/dwm.tmux
@@ -1,30 +1,22 @@
 #!/bin/sh
 
-window_panes=
-killlast=
-mfact=
-
 newpane() {
   tmux \
     split-window -t :.0\; \
     swap-pane -s :.0 -t :.1\; \
-    select-layout main-vertical\; \
-    resize-pane -t :.0 -x ${mfact}%
+    $layout
 }
 
 newpanecurdir() {
   tmux \
     split-window -t :.0 -c "#{pane_current_path}"\; \
     swap-pane -s :.0 -t :.1\; \
-    select-layout main-vertical\; \
-    resize-pane -t :.0 -x ${mfact}%
+    $layout
 }
 
 killpane() {
   if [ $window_panes -gt 1 ]; then
-    tmux kill-pane -t :.\; \
-         select-layout main-vertical\; \
-         resize-pane -t :.0 -x ${mfact}%
+    tmux kill-pane -t :.\; $layout
   else
     if [ $killlast -ne 0 ]; then
       tmux kill-window
@@ -33,11 +25,19 @@ killpane() {
 }
 
 nextpane() {
-  tmux select-pane -t :.+
+  if [ "$monocle" -eq 0 ]; then
+    tmux select-pane -t :.+
+  else
+    tmux select-pane -t :.+\; resize-pane -Z
+  fi
 }
 
 prevpane() {
-  tmux select-pane -t :.-
+  if [ "$monocle" -eq 0 ]; then
+    tmux select-pane -t :.-
+  else
+    tmux select-pane -t :.-\; resize-pane -Z
+  fi
 }
 
 # move current pane to a specific window
@@ -55,8 +55,7 @@ movepane() {
   # retile the current window
   tmux \
     move-pane -t:$window\; \
-    select-layout main-vertical\; \
-    resize-pane -t :.0 -x ${mfact}%
+    $layout
 
   # Select the window where we moved the pane
   if [ $newwin -ne 0 ]; then
@@ -68,28 +67,42 @@ movepane() {
   fi
 
   # Apply the dwm layout to the target window
-  tmux select-layout -t:$window main-vertical
-  tmux resize-pane -t:${window}.0 -x ${mfact}%
+  tmux $layout
 }
 
 rotateccw() {
-  tmux rotate-window -U\; select-pane -t 0
+  tmux rotate-window -U\; select-pane -t 0\; $layout
 }
 
 rotatecw() {
-  tmux rotate-window -D\; select-pane -t 0
+  tmux rotate-window -D\; select-pane -t 0\; $layout
 }
 
 zoom() {
-  tmux swap-pane -s :. -t :.0\; select-pane -t :.0
+  tmux swap-pane -s :. -t :.0\; select-pane -t :.0\; $layout
 }
 
-layouttile() {
-  tmux select-layout main-vertical\; resize-pane -t :.0 -x ${mfact}%
+tile() {
+  tmux \
+    setenv monocle 0\; \
+    select-layout main-vertical\; \
+    resize-pane -t :.0 -x ${mfact}%
 }
 
-float() {
-  tmux resize-pane -Z
+monocle() {
+  if [ "$monocle" -eq 0 ]; then
+    tmux \
+      setenv monocle 1\; \
+      resize-pane -Z
+  else
+    tmux \
+      setenv monocle 0\; \
+      resize-pane -Z
+  fi
+}
+
+layout() {
+  tmux $layout
 }
 
 incmfact() {
@@ -150,10 +163,17 @@ fi
 
 command=$1;shift
 args=$*
-set -- $(tmux display -p "#{window_panes} #{killlast} #{mfact}")
+set -- $(tmux display -p "#{window_panes} #{killlast} #{mfact} #{monocle}")
 window_panes=$1
-killlast=$2
-mfact=$3
+killlast=${2:-0}
+mfact=${3:-50}
+monocle=${4:-0}
+
+if [ "$monocle" -eq 1 ]; then
+  layout="select-layout main-vertical; resize-pane -t :.0 -x ${mfact}%; resize-pane -Z"
+else
+  layout="select-layout main-vertical; resize-pane -t :.0 -x ${mfact}%"
+fi
 
 case $command in
   newpane) newpane;;
@@ -164,8 +184,10 @@ case $command in
   rotateccw) rotateccw;;
   rotatecw) rotatecw;;
   zoom) zoom;;
-  layouttile) layouttile;;
-  float) float;;
+  tile) tile;;
+  float) monocle;; # retain for backwards compatibility
+  monocle) monocle;;
+  layout) layout;;
   incmfact) incmfact;;
   decmfact) decmfact;;
   window) window $args;;

--- a/lib/dwm.tmux
+++ b/lib/dwm.tmux
@@ -1,6 +1,7 @@
 setenv -g tmuxdwm_version 0.1.0
 setenv -g killlast 0 # Toggle killing last pane
 setenv -g mfact 50   # Main pane area factor
+setenv -g monocle 0
 
 set -g command-alias[100] newpane='run-shell "dwm.tmux newpane"'
 set -g command-alias[101] newpanecurdir='run-shell "dwm.tmux newpanecurdir"'
@@ -10,7 +11,7 @@ set -g command-alias[104] prevpane='run-shell "dwm.tmux prevpane"'
 set -g command-alias[105] rotateccw='run-shell "dwm.tmux rotateccw"'
 set -g command-alias[106] rotatecw='run-shell "dwm.tmux rotatecw"'
 set -g command-alias[107] zoom='run-shell "dwm.tmux zoom"'
-set -g command-alias[108] layouttile='run-shell "dwm.tmux layouttile"'
+set -g command-alias[108] tile='run-shell "dwm.tmux tile"'
 set -g command-alias[109] float='run-shell "dwm.tmux float"'
 set -g command-alias[110] incmfact='run-shell "dwm.tmux incmfact"'
 set -g command-alias[111] decmfact='run-shell "dwm.tmux decmfact"'
@@ -37,8 +38,10 @@ set -g command-alias[131] movepane6='run-shell "dwm.tmux movepane 6"'
 set -g command-alias[132] movepane7='run-shell "dwm.tmux movepane 7"'
 set -g command-alias[133] movepane8='run-shell "dwm.tmux movepane 8"'
 set -g command-alias[134] movepane9='run-shell "dwm.tmux movepane 9"'
+set -g command-alias[135] monocle='run-shell "dwm.tmux monocle"'
+set -g command-alias[136] layout='run-shell "dwm.tmux layout"'
 
-set-hook -g pane-exited 'run-shell "dwm.tmux layouttile"'
+set-hook -g pane-exited 'run-shell "dwm.tmux layout"'
 
 bind -n M-n newpane
 bind -n M-w newpanecurdir
@@ -48,8 +51,8 @@ bind -n M-k prevpane
 bind -n M-< rotateccw
 bind -n M-> rotatecw
 bind -n M-Enter zoom
-bind -n M-t layouttile
-bind -n M-Space float
+bind -n M-t tile
+bind -n M-Space monocle
 bind -n M-h decmfact
 bind -n M-l incmfact
 bind -n M-0 window0


### PR DESCRIPTION
Closes https://github.com/saysjonathan/dwm.tmux/issues/8. Currently layout mode is global (for better or worse). The pertag feature in https://github.com/saysjonathan/dwm.tmux/issues/11 would solve this.

This change has a couple of other changes as well:

* set default values for environment vars and remove duplicate declarations
* move `layouttile` to `tile`
* creates a `layout` function for enforcing the current layout (especially part of the `pane-exit` hook for enforcing outside of dwm.tmux control)
* `monocle` subsumes the `float` command. `M-space` works as expected but has the added benefit of enabling monocle mode overall
* `M-{j,k}` swap the fullscreen pane in monocle mode. The rotate commands effectively mirror this behavior when in monocle mode