### PR TITLE
Add commands to move position of focused pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ echo 'source-file /usr/local/lib/dwm.tmux' >> $HOME/.tmux.conf
 - `movepane[0-9]` `Meta-Shift-[0-9]` Move the current pane to the specified window
 - `nextpane` `Meta-j` Select the next pane (clockwise); swaps fullscreen pane in monocle mode
 - `prevpane` `Meta-k` Select the previous pane (counterclockwise); swaps fullscreen pane in monocle mode
+- `stackup` `Meta-J` Move focused pane up the stack
+- `stackdown` `Meta-K` Move focused pane down the stack
 - `rotateccw` `Meta-<` Rotate panes counterclockwise
 - `rotatecw` `Meta->` Rotate panes clockwise
 - `tile` `Meta-t` Return to tiled layout, exiting monocle if active
 - `monocle` `Meta-Space` Toggle monocle mode (fullscreen current pane)
-- `zoom` `Meta-Enter` Place select pane in the Main pane
+- `zoom` `Meta-Enter` Place selected pane in the Main pane
 - `decmfact` `Meta-h` Decrease the main pane space factor
 - `incmfact` `Meta-l` Increase the main pane space factor
 - `window[0-9]` `Meta-[0-9]` Select the target window by ID

--- a/bin/dwm.tmux
+++ b/bin/dwm.tmux
@@ -40,6 +40,18 @@ prevpane() {
   fi
 }
 
+stackup() {
+  if [ "$pane_index" -gt 1 ]; then
+    tmux swap-pane -U\; $layout
+  fi
+}
+
+stackdown() {
+  if [ "$pane_index" -lt $((window_panes - 1)) ] && [ "$pane_index" -ge 1 ]; then
+    tmux swap-pane -D\; $layout
+  fi
+}
+
 # move current pane to a specific window
 movepane() {
   window=$1
@@ -163,11 +175,12 @@ fi
 
 command=$1;shift
 args=$*
-set -- $(tmux display -p "#{window_panes} #{killlast} #{mfact} #{monocle}")
+set -- $(tmux display -p "#{window_panes} #{pane_index} #{killlast} #{mfact} #{monocle}")
 window_panes=$1
-killlast=${2:-0}
-mfact=${3:-50}
-monocle=${4:-0}
+pane_index=$2
+killlast=${3:-0}
+mfact=${4:-50}
+monocle=${5:-0}
 
 if [ "$monocle" -eq 1 ]; then
   layout="select-layout main-vertical; resize-pane -t :.0 -x ${mfact}%; resize-pane -Z"
@@ -195,5 +208,7 @@ case $command in
   killwindow) killwindow;;
   popup) popup;;
   movepane) movepane $args;;
+  stackup) stackup;;
+  stackdown) stackdown;;
   *) echo "unknown command"; exit 1;;
 esac

--- a/lib/dwm.tmux
+++ b/lib/dwm.tmux
@@ -40,6 +40,8 @@ set -g command-alias[133] movepane8='run-shell "dwm.tmux movepane 8"'
 set -g command-alias[134] movepane9='run-shell "dwm.tmux movepane 9"'
 set -g command-alias[135] monocle='run-shell "dwm.tmux monocle"'
 set -g command-alias[136] layout='run-shell "dwm.tmux layout"'
+set -g command-alias[137] stackup='run-shell "dwm.tmux stackup"'
+set -g command-alias[138] stackdown='run-shell "dwm.tmux stackdown"'
 
 set-hook -g pane-exited 'run-shell "dwm.tmux layout"'
 
@@ -48,6 +50,8 @@ bind -n M-w newpanecurdir
 bind -n M-c killpane
 bind -n M-j nextpane
 bind -n M-k prevpane
+bind -n M-J stackup
+bind -n M-K stackdown
 bind -n M-< rotateccw
 bind -n M-> rotatecw
 bind -n M-Enter zoom


### PR DESCRIPTION
This change adds the `stackup` and `stackdown` commands (and shortcuts) for moving panes around the stack. Addresses  https://github.com/saysjonathan/dwm.tmux/issues/9

* if pane is already at the top of the stack, moving upward is a noop
* if pane is already at the bottom of the stack, moving downwards is a noop
* if pane is main pane, it's a noop