### PR TITLE
Enable perwindow support

### DIFF
--- a/bin/dwm.tmux
+++ b/bin/dwm.tmux
@@ -110,7 +110,7 @@ zoom() {
 # Set the layout to tiled
 tile() {
   tmux \
-    setenv monocle 0\; \
+    set-option -w @monocle 0\; \
     select-layout main-vertical\; \
     resize-pane -t :.0 -x ${mfact}%
 }
@@ -119,11 +119,11 @@ tile() {
 monocle() {
   if [ "$monocle" -eq 0 ]; then
     tmux \
-      setenv monocle 1\; \
+      set-option -w @monocle 1\; \
       resize-pane -Z
   else
     tmux \
-      setenv monocle 0\; \
+      set-option -w @monocle 0\; \
       resize-pane -Z
   fi
 }
@@ -138,7 +138,7 @@ incmfact() {
   fact=$((mfact + 5))
   if [ $fact -le 95 ]; then
     tmux \
-      setenv mfact $fact\; \
+      set-option -w @mfact $fact\; \
       resize-pane -t :.0 -x ${fact}%
   fi
 }
@@ -148,7 +148,7 @@ decmfact() {
   fact=$((mfact - 5))
   if [ $fact -ge 5 ]; then
     tmux \
-      setenv mfact $fact\; \
+      set-option -w @mfact $fact\; \
       resize-pane -t :.0 -x ${fact}%
   fi
 }
@@ -200,7 +200,7 @@ command=$1;shift
 args=$@
 
 # Set positional arguments from tmux env var checks
-set -- $(tmux display -p "#{window_panes} #{pane_index} #{killlast} #{mfact} #{monocle}")
+set -- $(tmux display -p "#{window_panes} #{pane_index} #{killlast} #{@mfact} #{@monocle}")
 window_panes=$1
 pane_index=$2
 killlast=${3:-0}

--- a/lib/dwm.tmux
+++ b/lib/dwm.tmux
@@ -1,7 +1,7 @@
 setenv -g tmuxdwm_version 0.1.0
 setenv -g killlast 0 # Toggle killing last pane
-setenv -g mfact 50   # Main pane area factor
-setenv -g monocle 0
+set-option -wg @mfact 50   # Main pane area factor
+set-option -wg @monocle 0
 
 set -g command-alias[100] newpane='run-shell "dwm.tmux newpane"'
 set -g command-alias[101] newpanecurdir='run-shell "dwm.tmux newpanecurdir"'


### PR DESCRIPTION
This pull changes the `mfact` and `monocle` vars from being global to being window-scope using `set-option -w`. This enables per-window settings for the main pane size and layout choice.

Closes https://github.com/saysjonathan/dwm.tmux/issues/11