### PR TITLE
add support for ptags

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ dwm.tmux
 ![](https://raw.githubusercontent.com/saysjonathan/dwm.tmux/master/screenshot.png)
 
 ## Dependencies
-dwm.tmux requires tmux > 3.2.
+dwm.tmux requires tmux >= 3.2.
 
 ## Installation
 To install, use the provided `Makefile`:
@@ -16,7 +16,7 @@ cd dwm.tmux
 make
 ```
 
-By default `dwm.tmux` uses `/usr/local` as it's prefix. To change the prefix:
+By default `dwm.tmux` uses `/usr/local` as its prefix. To change the prefix:
 
 ```sh
 make PREFIX=$HOME
@@ -53,18 +53,24 @@ echo 'source-file /usr/local/lib/dwm.tmux' >> $HOME/.tmux.conf
 - `newwindow` `Meta-N` Create a new window starting in the same directory as the current pane
 - `killwindow` `Meta-X` Delete the current active window
 - `popup` `Meta-p` Display a floating pane popup in the current pane's directory
+- `incpfact` `Meta-.` Increase the size of the focused pane in the stack, relative to the other panes
+- `decpfact` `Meta-,` Decrease the size of the focused pane in the stack, relative to the other panes
+- `resetpfact` `Meta-=` Reset the pfact of the focused pane
 
-Also defined are environment variables to tweak behavior:
+Also defined are global options to tweak behavior:
 
 - `mfact` Main pane space factor, the size of the main pane as a percentage of total window size
-- `killlast` If value is greater than `0`, kill pane even if its the last pane in a window
+- `killlast` If value is greater than `0`, kill pane even if it is the last pane in a window
 - `monocle` Tracks active layout mode; 0 for tile, 1 for monocle. Set automatically but can be read to inspect current state.
+- `pfact` Per-pane stack size factor, scale 1-9, default 5. Higher values give the pane more relative height in the stack
 
 ### Customizations
 Keybindings and default values can be set in a configuration file:
 
 ```
 setenv -g killlast 1 # kill pane even if it's the last
+set-option -wg @mfact 60
+set-option -wg @pfact 4
 bind -n M-q killpane
 bind -n M-w newpanecurdir
 ```
@@ -85,4 +91,4 @@ Similar to dwm, windows are always organised as follows:
  ====================================
 ```
 
-A large Main pane is placed on the left side of the screen while a stack of smaller panes is placed on the right. The Main pane is always pane 0,  while the stack of panes is numbered sequentially in ascending order.
+A large Main pane is placed on the left side of the screen while a stack of smaller panes is placed on the right. The Main pane is always pane 0, while the stack of panes is numbered sequentially in ascending order.

--- a/bin/dwm.tmux
+++ b/bin/dwm.tmux
@@ -6,6 +6,8 @@ newpane() {
     split-window -t :.0\; \
     swap-pane -s :.0 -t :.1\; \
     $layout
+
+  applypfacts
 }
 
 # Create a new pane in the current directory in the current window
@@ -14,12 +16,15 @@ newpanecurdir() {
     split-window -t :.0 -c "#{pane_current_path}"\; \
     swap-pane -s :.0 -t :.1\; \
     $layout
+
+  applypfacts
 }
 
 # Kill the focused pane
 killpane() {
   if [ $window_panes -gt 1 ]; then
     tmux kill-pane -t :.\; $layout
+    applypfacts
   else
     # Only kill the last pane if $killlast is set
     if [ $killlast -ne 0 ]; then
@@ -51,6 +56,7 @@ stackup() {
   # Guard against moving panes 0 or 1
   if [ "$pane_index" -gt 1 ]; then
     tmux swap-pane -U\; $layout
+    applypfacts
   fi
 }
 
@@ -59,6 +65,7 @@ stackdown() {
   # Guard against moving the last pane or pane 0
   if [ "$pane_index" -lt $((window_panes - 1)) ] && [ "$pane_index" -ge 1 ]; then
     tmux swap-pane -D\; $layout
+    applypfacts
   fi
 }
 
@@ -79,6 +86,8 @@ movepane() {
     move-pane -t:$window\; \
     $layout
 
+  applypfacts
+
   # Select the window where we moved the pane
   if [ $newwin -ne 0 ]; then
     tmux \
@@ -90,21 +99,51 @@ movepane() {
 
   # Apply the dwm layout to the target window
   tmux $layout
+  applypfacts
+}
+
+# Increase the pfact of the focused pane
+incpfact() {
+  pfact=$(tmux display -p "#{@pfact}")
+  fact=$((pfact + 1))
+  if [ $fact -le 9 ]; then
+    tmux set-option -p @pfact $fact
+    applypfacts
+  fi
+}
+
+# Decrease the pfact of the focused pane
+decpfact() {
+  pfact=$(tmux display -p "#{@pfact}")
+  fact=$((pfact - 1))
+  if [ $fact -ge 1 ]; then
+    tmux set-option -p @pfact $fact
+    applypfacts
+  fi
+}
+
+# Reset the pfact of the focused pane
+resetpfact() {
+  tmux set-option -p @pfact 5
+  applypfacts
 }
 
 # Rotate the panes in the current window counterclockwise
 rotateccw() {
   tmux rotate-window -U\; select-pane -t 0\; $layout
+  applypfacts
 }
 
 # Rotate the panes in the current window clockwise
 rotatecw() {
   tmux rotate-window -D\; select-pane -t 0\; $layout
+  applypfacts
 }
 
 # Promote focused pane to main
 zoom() {
   tmux swap-pane -s :. -t :.0\; select-pane -t :.0\; $layout
+  applypfacts
 }
 
 # Set the layout to tiled
@@ -113,6 +152,8 @@ tile() {
     set-option -w @monocle 0\; \
     select-layout main-vertical\; \
     resize-pane -t :.0 -x ${mfact}%
+
+  applypfacts
 }
 
 # Toggle monocle mode, fullscreen focused pane
@@ -128,9 +169,40 @@ monocle() {
   fi
 }
 
+# Apply pfacts to panes in stack
+applypfacts() {
+  wp=$(tmux display -p "#{window_panes}")
+  [ $wp -le 2 ] && return
+
+  total_height=0
+  total_pfact=0
+  pane_data=""
+
+  while read -r index height ppfact; do
+    [ "$index" -eq 0 ] && continue
+    total_height=$((total_height + height))
+    total_pfact=$((total_pfact + ppfact))
+    pane_data="$pane_data $index:$ppfact"
+  done <<EOF
+$(tmux list-panes -F "#{pane_index} #{pane_height} #{@pfact}")
+EOF
+
+  cmd=""
+  for pane in $pane_data; do
+    index=${pane%%:*}
+    ppfact=${pane##*:}
+    height=$((ppfact * total_height / total_pfact))
+    [ -n "$cmd" ] && cmd="$cmd; "
+    cmd="${cmd}resize-pane -t :.$index -y $height"
+  done
+
+  tmux $cmd
+}
+
 # Reapply the current layout
 layout() {
   tmux $layout
+  applypfacts
 }
 
 # Increment the size of the main pane
@@ -236,5 +308,9 @@ case $command in
   movepane) movepane $args;;
   stackup) stackup;;
   stackdown) stackdown;;
+  incpfact) incpfact;;
+  decpfact) decpfact;;
+  resetpfact) resetpfact;;
+  applypfacts) applypfacts;;
   *) echo "unknown command"; exit 1;;
 esac

--- a/lib/dwm.tmux
+++ b/lib/dwm.tmux
@@ -2,6 +2,7 @@ setenv -g tmuxdwm_version 0.1.0
 setenv -g killlast 0 # Toggle killing last pane
 set-option -wg @mfact 50   # Main pane area factor
 set-option -wg @monocle 0
+set-option -wg @pfact 5 # default pane factor, scale 1-9
 
 set -g command-alias[100] newpane='run-shell "dwm.tmux newpane"'
 set -g command-alias[101] newpanecurdir='run-shell "dwm.tmux newpanecurdir"'
@@ -42,6 +43,9 @@ set -g command-alias[135] monocle='run-shell "dwm.tmux monocle"'
 set -g command-alias[136] layout='run-shell "dwm.tmux layout"'
 set -g command-alias[137] stackup='run-shell "dwm.tmux stackup"'
 set -g command-alias[138] stackdown='run-shell "dwm.tmux stackdown"'
+set -g command-alias[139] incpfact='run-shell "dwm.tmux incpfact"'
+set -g command-alias[140] decpfact='run-shell "dwm.tmux decpfact"'
+set -g command-alias[141] resetpfact='run-shell "dwm.tmux resetpfact"'
 
 set-hook -g pane-exited 'run-shell "dwm.tmux layout"'
 
@@ -83,4 +87,7 @@ bind -n M-& movepane7
 bind -n M-* movepane8
 bind -n M-( movepane9
 bind -n M-` last-window
+bind -n M-. incpfact
+bind -n M-, decpfact
+bind -n M-= resetpfact
 bind -n M-b set-option -g status


### PR DESCRIPTION
This change adds support for ptags, per-pane height sizing in the stack similar to [cfacts](https://dwm.suckless.org/patches/cfacts/) in dwm. This change adds three commands, `incpfact`, `decpfact`, and `resetpfact`, along with their respective keyboard shortcuts. A global pfact option is set and can be overridden by users. Due to their dependency on the layout during render time, the application of pfacts (via `applypfacts`) must be run after other tmux commands which alter the layout or pane count. This means that many functions now require two tmux calls in order to execute. In my testing this has not introduced a burdensome amount of additional latency but it's something to watch.

Closes https://github.com/saysjonathan/dwm.tmux/issues/10